### PR TITLE
Fixing evpn type not showing

### DIFF
--- a/netbox_evpn_vc/templates/netbox_evpn_vc/vlan_evpn_vc.html
+++ b/netbox_evpn_vc/templates/netbox_evpn_vc/vlan_evpn_vc.html
@@ -20,7 +20,7 @@
                         <span>Type</span>
                     </td>
                     <td>
-                        <span>{{ evpnvcvlan.vc_type.name }}</span>
+                        <span>{{ evpnvcvlan.evpn_vc.vc_type.name }}</span>
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
On the VLAN page the EVPN type did not show, this makes sure it shows


![Screenshot 2022-06-08 095555](https://user-images.githubusercontent.com/7995002/172563203-d802947a-2647-4f8f-812e-658f72404f70.png)

